### PR TITLE
Update Assets-constructor

### DIFF
--- a/src/Assets.php
+++ b/src/Assets.php
@@ -85,6 +85,10 @@ class Assets
         $this->baseUrl = $baseUrl;
         $this->assetsPath = $alias->get('@web') . '/' . $this->assetsDir;
         $this->assetsUrl = $baseUrl . '/' . $this->assetsDir;
+        // local url should begin with single slash, if document-root points to web-dir
+        if(substr($this->assetsUrl,0,2)=='//'){
+            $this->assetsUrl = substr($this->assetsUrl,1);
+        }
     }
 
     /**


### PR DESCRIPTION
local assetsUrl should begin with single slash, if document-root points directly into web-dir

Hi Thomas,
dies sollte die Fehlermeldung von [antondachauer](https://github.com/getherbie/herbie/issues/8#issuecomment-124266436) beseitigen, aber vielleicht gehts auch eleganter. 
Viele Grüße,
Andreas

P.S. Mein Herbie-Fork hat einige Änderungen, die eigentlich nur in meiner Installation Sinn machen und normale Installationen abschiessen würden. Du müsstest also punktuell nur diesen pull-request mergen!
