### PR TITLE
Enable self-contained blocks aka widgets

### DIFF
--- a/plugins/shortcode/shortcode.php
+++ b/plugins/shortcode/shortcode.php
@@ -206,12 +206,20 @@ class ShortcodePlugin
 
             foreach ($collection as $i => $item) {
 
+                if (!empty($options['name']) && ($options['name'] != $i)) {
+                    continue;
+                }
+
                 $block = Herbie\Page::create($item->path);
 
                 DI::set('Page', $block);
 
                 if (!empty($block->layout) && ($block->layout == 'default.html')) {
                     $block->layout = false;
+                }
+
+                if (!empty($block->layout) && file_exists($paths[$path].'/.'.$i.'/'.$block->layout)) {
+                    $block->layout = $path.'/.'.$i.'/'.$block->layout;
                 }
 
                 if (empty($block->layout)) {


### PR DESCRIPTION
Hi Thomas,
was hältst Du von dieser Änderung? Damit könnte man Blocks einzeln einbinden und ihnen ein eigenes Template mitgeben. Mein Anwendungsfall wäre: Der Kunde, der seine Seite nicht übers Web, sondern nur über seinen ownCloud- o. Dropbox-Ordner editiert, bekommt eine Mail mit dem neuen Block (zB Slider, Formular etc) als zip-Datei und baut ihn einfach per drag&drop in seine Seite ein.

Viele Grüße
Andreas