### PR TITLE
Bugfix: blogs always get rendered at the beginning of the segment

### DIFF
--- a/plugins/markdown/markdown.php
+++ b/plugins/markdown/markdown.php
@@ -37,7 +37,7 @@ class MarkdownPlugin
                 return $content;
             }
             return MarkdownPlugin::parseMarkdown($content);
-        });
+        },9);
     }
 
     public static function addShortcode($shortcode)

--- a/plugins/shortcode/shortcode.php
+++ b/plugins/shortcode/shortcode.php
@@ -177,6 +177,8 @@ class ShortcodePlugin
     protected function addBlocksTag()
     {
         $this->add('blocks', function ($options) {
+            
+            $return = '';
 
             $options = array_merge([
                 'path' => DI::get('Page')->getDefaultBlocksPath(),
@@ -218,10 +220,10 @@ class ShortcodePlugin
                 }
 
                 if (empty($block->layout)) {
-                    echo $twig->renderPageSegment(0, $block);
+                    $return .= $twig->renderPageSegment(0, $block);
                 } else {
                     $twig->getEnvironment()->getExtension('herbie')->setPage($block);
-                    echo $twig->render($block->layout);
+                    $return .= $twig->render($block->layout);
                 }
                 ob_flush();
             }
@@ -230,7 +232,8 @@ class ShortcodePlugin
             $twig->getEnvironment()->getExtension('herbie')->setPage($page);
             DI::set('Page', $page);
 
-            return ob_get_clean();
+            ob_get_clean();
+            return $return;
         });
     }
 


### PR DESCRIPTION
Hi Thomas,
lass Dich nicht von mir nerven, ich bastel gerade fieberhaft an einem neuen Projekt und da fällt mir halt ab und zu was auf.
Wenn die blocke nicht in einer Variablen gespeichert sondern direkt über den Ausgabepuffer ausgegeben werden, ordnen die sich immer an erster Stelle im Segment an.

Warum auch immer...

Ansonsten macht mir die neue Version echt viel Spass!

Viele Grüße,
Andreas