### PR TITLE
Ignore BOM in Page- and FrontMatterLoader

### DIFF
--- a/system/Loader/FrontMatterLoader.php
+++ b/system/Loader/FrontMatterLoader.php
@@ -22,14 +22,18 @@ class FrontMatterLoader
      */
     public function load($path)
     {
+        if(!defined('UTF8_BOM')) {
+            define('UTF8_BOM', chr(0xEF).chr(0xBB).chr(0xBF));
+        }
+        
         $yaml = '';
 
         $fileObject = new \SplFileObject($path);
 
         $i = 0;
         foreach ($fileObject as $line) {
-            // strip \n and \r from end of line
-            $line = rtrim($line, "\n\r");
+            // strip BOM from the beginning and \n and \r from end of line
+            $line = rtrim(ltrim($line, UTF8_BOM), "\n\r");
             if (preg_match('/^---$/', $line)) {
                 $i++;
                 continue;

--- a/system/Loader/PageLoader.php
+++ b/system/Loader/PageLoader.php
@@ -99,10 +99,14 @@ class PageLoader
      */
     protected function parseContent($content)
     {
+        if(!defined('UTF8_BOM')) {
+            define('UTF8_BOM', chr(0xEF).chr(0xBB).chr(0xBF));
+        }
+        
         $yaml = '';
         $segments = [];
 
-        $matched = preg_match('/^-{3}\r?\n(.*)\r?\n-{3}\R(.*)/ms', $content, $matches);
+        $matched = preg_match('/^['.UTF8_BOM.']*-{3}\r?\n(.*)\r?\n-{3}\R(.*)/ms', $content, $matches);
 
         if ($matched === 1 && count($matches) == 3) {
             $yaml = $matches[1];


### PR DESCRIPTION
Hi Thomas,

frohes Neues, hoffe Du bist gut ins neue Jahr gekommen.
Ich würde Herbie gerne auch von unterwegs aus administrieren können, zB Blogeinträge schreiben etc. Aber viele Apps setzen noch einen BOM an den Dateianfang und dann ist nur noch eine Twig-Fehlermeldung zu sehen, dass die Inhalte nicht eingelesen werden können.
Könntest Du meine Änderungen so oder so ähnlich übernehmen?
Viele Grüße
Andreas
