### PR TITLE
Feature/yml shortcodes

### DIFF
--- a/plugins/shortcode/shortcode.php
+++ b/plugins/shortcode/shortcode.php
@@ -14,6 +14,12 @@ class ShortcodePlugin
     {
         $this->config = DI::get('Config');
         $tags = $this->config->get('plugins.config.shortcode', []);
+
+        // Feature 20160224: Define simple shortcodes also in config.yml
+        foreach($tags as $tag => $_callable){
+            $tags[$tag] = create_function('$atts, $content', $_callable.';');
+        }
+        
         $this->shortcode = new Shortcode($tags);
         DI::set('Shortcode', $this->shortcode);
     }

--- a/plugins/twig/classes/HerbieExtension.php
+++ b/plugins/twig/classes/HerbieExtension.php
@@ -381,7 +381,10 @@ class HerbieExtension extends Twig_Extension implements Twig_Extension_GlobalsIn
         if (empty($wrap)) {
             return $content;
         }
-        return sprintf('<div class="placeholder-%s">%s</div>', $segmentId, $content);
+        if(!$placeholderName = $this->config->get('twig.content_container_class')){
+            $placeholderName = 'placeholder';
+        }
+        return sprintf('<div class="'.$placeholderName.'-%s">%s</div>', $segmentId, $content);
     }
 
     /**


### PR DESCRIPTION
Hallo Thomas,
hier der PR um einfache shortcodes auch in der config.yml definieren zu können.

Entschuldigung, leider hat sich hier auch die vorherige Änderung (content-wrapper-classes) nochmal eingeschlichen. Ich übe noch!

Viele Grüße
Andreas
