### PR TITLE
Hotfix/wrong url generated if empty

### DIFF
--- a/system/Url/UrlGenerator.php
+++ b/system/Url/UrlGenerator.php
@@ -74,6 +74,7 @@ class UrlGenerator
     protected function filterUrl($url)
     {
         $url = preg_replace('/\/index$/', '', $url);
-        return empty($url) ? '/' : rtrim($url, '/');
+        $url = rtrim($url, '/');
+        return empty($url) ? '/' : $url;
     }
 }


### PR DESCRIPTION
Hi Thomas,

der letzte PR für heute :-)
Bei mir am Mac/MAMP bekomme ich immer wieder "leere" Links, zB im adminpanel bei Klick auf "Frontend".

Viele Grüße
Andreas
